### PR TITLE
ActionView::Helpers::TagHelper include moved from main scope to Bbcode::HtmlHandler

### DIFF
--- a/lib/bbcode.rb
+++ b/lib/bbcode.rb
@@ -11,8 +11,6 @@ require "bbcode/html_handler"
 require "bbcode/base"
 require "bbcode/helpers"
 
-include ActionView::Helpers::TagHelper
-
 module Bbcode
 	String.send :include, Bbcode::Helpers
 

--- a/lib/bbcode/html_handler.rb
+++ b/lib/bbcode/html_handler.rb
@@ -2,6 +2,8 @@ require "bbcode/handler"
 
 module Bbcode
 	class HtmlHandler < Handler
+		include ActionView::Helpers::TagHelper
+			
 		def initialize( element_handlers = nil )
 			super :"#text" => ->(text){ CGI.escapeHTML(text) }
 			register_element_handlers element_handlers unless element_handlers.nil?


### PR DESCRIPTION
including ActionView::Helpers::TagHelper into main scope breaks active_admin, causing this issue: [gregbell/active_admin#827](https://github.com/gregbell/active_admin/issues/827)
